### PR TITLE
Add development environment setup (AGENTS.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyc
 
 # Bot data (contains guild configs, rate state)
+data/bot.log
 data/config.json
 data/karma_history.jsonl
 data/rate_state/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+## Cursor Cloud specific instructions
+
+### Overview
+Sir-5rM8 is a Python Discord bot for ARK: Survival Ascended communities. It is a single-service application (not a monorepo). The entry point is `main.py`.
+
+### Running the bot
+- **Start:** `python main.py` (requires `TOKEN` env var or `.env` file with `TOKEN=<discord_bot_token>`)
+- The bot has a staggered startup delay (15–45s random) built into `main.py`. Set `LOGIN_RETRY_ATTEMPT=5` to bypass retry logic for quick exit during testing.
+- Without a valid Discord bot token, the bot raises `ValueError("TOKEN not set...")`. This is expected.
+
+### Storage
+- Default: local JSON files in `data/`. No database needed.
+- Optional: Supabase (set `SUPABASE_URL` + `SUPABASE_SERVICE_KEY` in `.env`). Schema in `docs/supabase_schema.sql`.
+
+### Testing core functionality without a token
+All non-Discord functionality can be tested directly:
+```python
+from utils.asa import fetch_current_rates, find_server
+rates = fetch_current_rates()         # fetches live ASA rates from CDN
+server = find_server('5313')          # looks up an ARK server
+```
+```python
+from utils.storage_files import save_previous_rate_values, get_previous_rate_values
+save_previous_rate_values({'XPMultiplier': '2.0'})
+get_previous_rate_values()
+```
+Bot extensions can be loaded without connecting to Discord:
+```python
+import asyncio
+from main import load_extensions, bot
+asyncio.run(load_extensions())
+```
+
+### Linting / Tests
+There is no linter or test framework configured in this repo. Basic validation is: ensure all modules import without error and core API calls succeed.
+
+### Key gotchas
+- PyNaCl/davey warnings at startup are harmless (voice is unused).
+- The ARK CDN APIs (`cdn2.arkdedicated.com`) are public and require no auth.
+- The `data/` directory is auto-created on first run.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for the Sir-5rM8 Discord bot, and adds `data/bot.log` to `.gitignore`.

## What's included

- **AGENTS.md** — Documents how to run the bot, test core functionality without a Discord token, storage backends, and key development gotchas.
- **.gitignore** — Added `data/bot.log` (runtime log artifact generated by the bot's logging on startup).

## Environment validation

All checks pass — dependencies install, all 12 project modules import, ARK CDN APIs respond, local file storage round-trips correctly, and all 6 bot extensions load.

[dev_env_validation.log](https://cursor.com/agents/bc-0dd2b08e-69fb-4e84-a603-f6dbda67668c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_env_validation.log)

## Update script

```
pip install -r requirements.txt
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dd2b08e-69fb-4e84-a603-f6dbda67668c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dd2b08e-69fb-4e84-a603-f6dbda67668c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

